### PR TITLE
A few fixups to git-branch-description

### DIFF
--- a/git-branch-description
+++ b/git-branch-description
@@ -75,7 +75,7 @@ printf '%*s' "${C:-$(($COLS/2-5))}" | tr ' ' =
 printf "${YELLOW} Activity $RESET"
 printf '%*s\n' "${C:-$(($COLS/2-5))}" | tr ' ' =
 
-git reflog -v -n40 --date=relative --grep-reflog="from $branch" --grep-reflog="to $branch" HEAD
+git --no-pager reflog -v -n40 --date=relative --grep-reflog="from $branch" --grep-reflog="to $branch" HEAD
 
 
 #git --no-pager reflog show --pretty --no-abbrev-commit $branch


### PR DESCRIPTION
I'm not sure if you chose to allow the pager in git-branch-description as I saw the commented-out line underneath the git reflog command which does have --no-pager.
