### PR TITLE
README.md: indent example blocks by 4 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,17 @@ Splitting commits
 -----------------
 During rebase, when you realise that a commit needs to be broken up into
 two.
-   $> git rebase -i
-   # mark commit to split as "edit"
-   $> git split-commit
+
+    $> git rebase -i
+    # mark commit to split as "edit"
+    $> git split-commit
 
 The tool now calls git add -p, letting you add the hunks needed (and/or missing
 files). Finish up, it will re-commit with the same message and drop you
 back to the shell to finish up and continue. Alternatively,
 
-   $> git split-commit --after
+    $> git split-commit --after
+    
 will drop you into a shell immediately, letting you git add and commit
 anything you want committed _before_ the current commit. Exiting the shell
 will commit the rest.
@@ -100,13 +102,14 @@ of commits starting with "squash!" or "fixup!", followed by a subject line
 that matches an earlier commit.
 
 git-squash is a wrapper script around that to make it easier to remember.
-   $> git add myfile yourfile
-   $> git squash
-   [1] this is the most recent commit
-   [2] previos commit
-   [3] some other commit
-   [4] a commit message
-   Number to squash in: 3
+
+    $> git add myfile yourfile
+    $> git squash
+    [1] this is the most recent commit
+    [2] previos commit
+    [3] some other commit
+    [4] a commit message
+    Number to squash in: 3
 
 Arguments passed to git-squash will be passed to git-commit.
 
@@ -117,7 +120,7 @@ Some projects request Reviewed-by, Signed-off-by or bugzilla references to
 be adeed to a commit message. git-add-tag is a script to add these to a set
 of commit messages.
 
-   $> git add-tag HEAD~6..
+    $> git add-tag HEAD~6..
 
 This will open up an editor window. Write the line you need to add to the
 commit range and exit. The line will be appended to all commits in the


### PR DESCRIPTION
This makes them show up properly as `<pre>` blocks in GitHub.
