### PR TITLE
git-squash: support Bash from Windows Git

### DIFF
--- a/git-squash
+++ b/git-squash
@@ -31,17 +31,20 @@ esac
 
 declare -a ref=()
 
+IFS='
+'
+refs=($(git log --format="%s" -n $nrefs))
+
 i=0
-while read ref; do
+for ref in "${refs[@]}"; do
     i=$(($i + 1))
-    refs[$i]="$ref"
     echo "[$i] $ref"
-done < <(git log --format="%s" -n $nrefs)
+done
 
 echo -n "Number to squash in: "
 read r
 
-ref=${refs[$r]}
+ref=${refs[$r-1]}
 
 git commit -m "fixup! $ref" $@
 


### PR DESCRIPTION
Bash from the Windows Git distribution does not support process
substitution:

```
$ git squash
d:\ext\git-branch-tools\git-squash: cannot make pipe for process substitution: Function not implemented
d:\ext\git-branch-tools\git-squash: cannot make pipe for process substitution: Function not implemented
d:\ext\git-branch-tools\git-squash: line 39: <(git log --format="%s" -n $nrefs): ambiguous redirect
Number to squash in:
```

Joy. So instead, let's read `git log` straight into the 'refs' array,
and iterate it to produce the menu.

I understand if you don't want to accept patches which dirty the code to gain Windows support. This is the best I could come up with, but maybe someone who speaks better Bash can think of a better way?
