### PR TITLE
recent-branches: Make limit configurable

### DIFF
--- a/git-recent-branches
+++ b/git-recent-branches
@@ -247,8 +247,16 @@ def walk_reflog(args, repo):
         if args.limit > 0 and n >= args.limit:
             break
 
+def get_configured_limit(repo):
+    config = repo.config_reader()
+    value = config.get_value("recent-branches", "limit", 20)
+    return value
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
+
+    repo = init_repo()
+    default_limit = get_configured_limit(repo)
 
     parser = argparse.ArgumentParser(description="Show a list of recently used branches",
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -270,7 +278,7 @@ if __name__ == "__main__":
                         help="Show top commit on each branch. Uses git log, use git log options for formatting the output")
     parser.add_argument("--limit",
                         type=int,
-                        default=20,
+                        default=default_limit,
                         help="Limit output to N branches")
     parser.add_argument("log_options",
                         nargs="*",
@@ -280,5 +288,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args(sys.argv[1:])
 
-    repo = init_repo()
     walk_reflog(args, repo)

--- a/git-recent-branches
+++ b/git-recent-branches
@@ -52,7 +52,7 @@ def reltime_to_now(t, tzoff):
 
     return "%d %s ago" % (count, word(count))
 
-def find_repo(args):
+def find_repo():
     """Run up from $PWD until the end of the filesystem, trying to find the
        git repo. This emulates what git does by default."""
 
@@ -74,8 +74,8 @@ def find_repo(args):
 
     return gitdir
 
-def init_repo(args):
-    gitdir = os.environ.get("GIT_DIR", find_repo(args))
+def init_repo():
+    gitdir = os.environ.get("GIT_DIR", find_repo())
     if not git.repo.fun.is_git_dir(gitdir):
         error("fatal: Not a git repository")
         sys.exit(1)
@@ -280,5 +280,5 @@ if __name__ == "__main__":
 
     args = parser.parse_args(sys.argv[1:])
 
-    repo = init_repo(args)
+    repo = init_repo()
     walk_reflog(args, repo)

--- a/git-recent-branches
+++ b/git-recent-branches
@@ -270,7 +270,7 @@ if __name__ == "__main__":
                         help="Show top commit on each branch. Uses git log, use git log options for formatting the output")
     parser.add_argument("--limit",
                         type=int,
-                        default=-1,
+                        default=20,
                         help="Limit output to N branches")
     parser.add_argument("log_options",
                         nargs="*",


### PR DESCRIPTION
The number of "recent branches" got out of hand (200+) meaning the
relevant ones were already out of view of my maximized terminal window.
Add way to configure the limit to make the list of recent branches more
digestible, without having to pass flags each time.

To configure, add the following to ~/.gitconfig:

[recent-branches]
	limit = 20

To limit the number of listed branches to 20.