### PR TITLE
git-recent-branches: fix our counter ending up as float

### DIFF
--- a/git-recent-branches
+++ b/git-recent-branches
@@ -29,7 +29,7 @@ def reltime_to_now(t, tzoff):
     utc_sec = t - tzoff;
     now_utc_sec = time.time() - time.timezone
 
-    delta = now_utc_sec - utc_sec
+    delta = int(now_utc_sec - utc_sec)
 
     if delta < 0:
         logging.error("Date is in the future?")


### PR DESCRIPTION
Because the delta is a float, count ends up being a float even after the integer division. This causes warnings on Python 3.13:

  git-recent-branches:43: DeprecationWarning: Plural value must be an integer, got float
    (60 * 60, lambda n : gettext.ngettext("hour", "hours", n)),

Closes #9